### PR TITLE
[PKG-4541] 1.9.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,23 +17,22 @@ build:
 
 requirements:
   host:
-    - hatch
+    - hatchling
     - pip
     - python
   run:
-    - folium
-    - gdal
-    - geopandas
-    - matplotlib-base
-    - networkx
-    - numpy
-    - pandas
-    - python >=3.8
-    - rasterio
-    - requests
-    - scipy
-    - scikit-learn
+    - geopandas >=0.12
+    - networkx >=2.5
+    - numpy >=1.20
+    - pandas >=1.1
+    - python
+    - requests >=2.27
     - shapely >=2.0
+  run_constrained:
+    - scipy >=1.5
+    - scikit-learn >=0.23
+    - matplotlib-base >=3.5
+    - rasterio
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   skip: true  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
+  skip: true  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -19,7 +19,7 @@ requirements:
   host:
     - hatch
     - pip
-    - python >=3.8
+    - python
   run:
     - folium
     - gdal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,10 @@ requirements:
 test:
   imports:
     - osmnx
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://osmnx.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ test:
     - pre-commit
     - hatchling
     - folium
+    - pyproj >=3.0
   commands:
     - pip check
     - pytest tests -k "not test_elevation"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "osmnx" %}
 {% set version = "1.9.3" %}
-{% set sha256 = "48775ffb28d25bf95d12d9fcb8fd6872d082891724077b5f063d6d02ae816000" %}
+{% set sha256 = "22548d86d68d36edff3cf9ab76c45745cda86a4ea0b28442e107d6b42992a426" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/gboeing/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -35,20 +35,12 @@ requirements:
     - rasterio >=1.3
 
 test:
-  source_files:
-    - tests
   imports:
     - osmnx
   requires:
     - pip
-    - pytest
-    - pre-commit
-    - hatchling
-    - folium
-    - pyproj >=3.0
   commands:
     - pip check
-    - pytest tests -k "not test_elevation"
 
 about:
   home: https://osmnx.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "osmnx" %}
 {% set version = "1.9.3" %}
-{% set sha256 = "22548d86d68d36edff3cf9ab76c45745cda86a4ea0b28442e107d6b42992a426" %}
+{% set sha256 = "48775ffb28d25bf95d12d9fcb8fd6872d082891724077b5f063d6d02ae816000" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/gboeing/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -35,12 +35,19 @@ requirements:
     - rasterio >=1.3
 
 test:
+  source_files:
+    - tests
   imports:
     - osmnx
   requires:
     - pip
+    - pytest
+    - pre-commit
+    - hatchling
+    - folium
   commands:
     - pip check
+    - pytest tests -k "not test_elevation"
 
 about:
   home: https://osmnx.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  skip: true  # [py<38]
+  skip: true  # [py<38 or s390x]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - scipy >=1.5
     - scikit-learn >=0.23
     - matplotlib-base >=3.5
-    - rasterio
+    - rasterio >=1.3
 
 test:
   imports:


### PR DESCRIPTION
osmnx 1.9.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4541]
- [Upstream repository](https://github.com/gboeing/osmnx)
- [Upstream changelog/diff](https://github.com/gboeing/osmnx/blob/v1.9.3/CHANGELOG.md)

### Explanation of changes:

- Skipped s390x due to missing `geopandas >=0.12`
- Tests require unavailable `rasterio >=1.3` 


[PKG-4541]: https://anaconda.atlassian.net/browse/PKG-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ